### PR TITLE
feat: lint PR title for conventional commits

### DIFF
--- a/.github/rulesets/protect-main-branch.json
+++ b/.github/rulesets/protect-main-branch.json
@@ -36,7 +36,11 @@
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
-            "context": "test",
+            "context": "🧪 Test and 🚀 Release",
+            "integration_id": 15368
+          },
+          {
+            "context": "🔍 Lint PR Title",
             "integration_id": 15368
           }
         ]

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,51 @@
+name: 🔍 Lint PR Title
+
+# The PR title becomes the squash commit message on main (squash_merge_commit_title
+# is set to PR_TITLE), and semantic-release parses that message to determine the
+# version bump. So the PR title, not the branch's individual commits, is what must
+# follow Conventional Commits.
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions: {}
+
+jobs:
+  lint-pr-title:
+    name: 🔍 Lint PR Title
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: "package.json"
+
+      - name: 🗄 Cache node_modules
+        id: cache-node_modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: "**/node_modules"
+          key: node_modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: 🔍 Install dependencies
+        if: steps.cache-node_modules.outputs.cache-hit != 'true'
+        run: |
+          npm ci --ignore-scripts --prefer-offline --no-audit --strict-peer-deps
+
+      - name: 🔍 Lint PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "$PR_TITLE" | npx commitlint --verbose


### PR DESCRIPTION
## Summary
- Adds a new `🔍 Lint PR Title` workflow that runs commitlint against the PR title on open/edit/sync/reopen, since squash-merge uses the PR title as the commit message on `main` that semantic-release parses for version bumps.
- Fixes a stale required-status-check entry in `.github/rulesets/protect-main-branch.json` (`"test"` didn't match any real check name) and adds the new PR title check as required.

## Test plan
- [ ] Merge and confirm the "🔍 Lint PR Title" check appears on PRs
- [ ] Import the updated ruleset via Settings → Rules → Rulesets, or mark the check required manually
- [ ] Open a PR with a non-conventional title to confirm the check fails